### PR TITLE
Bump sequelize version to fix github security warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Address History API
 
-This API provides a set of endpoints that allows the user to perform CRUD operations on an `Address` model as well as to view historical versions of an address by looking at the events that have taken place on the Address. 
+This API provides a set of endpoints that allows the user to perform CRUD operations on an `Address` model as well as to view historical versions of an address by looking at the events that have taken place on the Address.
 
 ## Running the Server
 
-The only prerequisite for running this server is to have [Docker](https://docs.docker.com/install/) installed. 
+The only prerequisite for running this server is to have [Docker](https://docs.docker.com/install/) installed.
 
 Once you have Docker installed and have cloned this repository into a local folder you can run the following:
 
@@ -115,7 +115,7 @@ The response contains the updated address.
 
 ### `DELETE /addresses/{address_id}`
 
-Delete an existing address using its `id`. This endpoint responds with no content. 
+Delete an existing address using its `id`. This endpoint responds with no content.
 
 ### `POST /addresses/{address_id}/restore`
 
@@ -125,10 +125,10 @@ The API supports **restoring** a deleted address using this endpoint. It respond
 
 ### `GET /addresses/{address_id}/events`
 
-You can use this endpoint to see an ordered list of all the events that have occurred for a given address. 
+You can use this endpoint to see an ordered list of all the events that have occurred for a given address.
 
 - The sample below contains one of each possible event `type`
-- The `payload` is the body of the request that triggered the event. 
+- The `payload` is the body of the request that triggered the event.
 - The `url` is a direct link to view the full address with the correct `as_of` populated
 
 ```json

--- a/app/features/addresses.js
+++ b/app/features/addresses.js
@@ -97,7 +97,7 @@ exports.register = (server, options, next) => {
     config: {
       tags: ['api'],
       handler: (request, reply) => {
-        State.findById(request.payload.state.toUpperCase())
+        State.findByPk(request.payload.state.toUpperCase())
         .then(state => {
           if (!state) throw server.plugins.errors.invalidState
 
@@ -136,7 +136,7 @@ exports.register = (server, options, next) => {
         P.resolve()
         .then(() => {
           if (request.payload.state) {
-            return State.findById(request.payload.state.toUpperCase())
+            return State.findByPk(request.payload.state.toUpperCase())
             .then(_state => {
               if (!_state) throw server.plugins.errors.invalidState
               state = _state

--- a/app/features/addresses.js
+++ b/app/features/addresses.js
@@ -1,6 +1,9 @@
 const Joi = require('joi')
 const P   = require('bluebird')
 
+const Sequelize = require('sequelize')
+const Op = Sequelize.Op
+
 exports.register = (server, options, next) => {
 
   const Events = options.events
@@ -210,7 +213,9 @@ exports.register = (server, options, next) => {
         Address.findOne({
           where: {
             id: request.params.addressId,
-            deleted_at: {$ne: null}
+            deleted_at: {
+              [Op.ne]: null
+            }
           }
         })
         .then(address => {

--- a/app/models/address.js
+++ b/app/models/address.js
@@ -1,7 +1,7 @@
 const Sequelize = require('sequelize')
 
 module.exports = db => {
-  return db.define('address', {
+  const Address = db.define('address', {
     id: {type: Sequelize.UUID, defaultValue: Sequelize.UUIDV1, primaryKey: true},
     user_id: {type: Sequelize.STRING(255), allowNull: false},
     street_one: {type: Sequelize.STRING(255), allowNull: false},
@@ -13,40 +13,41 @@ module.exports = db => {
     deleted_at: Sequelize.DATE
   }, {
     paranoid: false,
-    deletedAt: false,
-    instanceMethods: {
-      process: function (eventType, event, inMemory = false) {
-        switch (eventType) {
-          case 'ADDRESS_CREATED':
-            this.id = event.id
-            this.user_id = event.user_id
-            this.street_one = event.street_one
-            this.street_two = event.street_two
-            this.city = event.city
-            this.state_id = event.state_id
-            this.zip_code = event.zip_code
-            if (!inMemory) return this.save()
-            break
-          case 'ADDRESS_UPDATED':
-            ['street_one', 'street_two', 'city', 'state_id', 'zip_code'].forEach(key => {
-              if (event[key] !== undefined) {
-                this[key] = event[key]
-              }
-            })
-            if (!inMemory) return this.save()
-            break
-          case 'ADDRESS_DELETED':
-            this.deleted_at = event.deleted_at
-            if (!inMemory) return this.save()
-            break
-          case 'ADDRESS_RESTORED':
-            this.deleted_at = null
-            if (!inMemory) return this.save()
-            break
-          default:
-            console.log(event.type, 'event not supported')
-        }
-      }
-    }
+    deletedAt: false
   })
+
+  Address.prototype.process = function (eventType, event, inMemory = false) {
+    switch (eventType) {
+      case 'ADDRESS_CREATED':
+        this.id = event.id
+        this.user_id = event.user_id
+        this.street_one = event.street_one
+        this.street_two = event.street_two
+        this.city = event.city
+        this.state_id = event.state_id
+        this.zip_code = event.zip_code
+        if (!inMemory) return this.save()
+        break
+      case 'ADDRESS_UPDATED':
+        ['street_one', 'street_two', 'city', 'state_id', 'zip_code'].forEach(key => {
+          if (event[key] !== undefined) {
+            this[key] = event[key]
+          }
+        })
+        if (!inMemory) return this.save()
+        break
+      case 'ADDRESS_DELETED':
+        this.deleted_at = event.deleted_at
+        if (!inMemory) return this.save()
+        break
+      case 'ADDRESS_RESTORED':
+        this.deleted_at = null
+        if (!inMemory) return this.save()
+        break
+      default:
+        console.log(event.type, 'event not supported')
+    }
+  }
+
+  return Address
 }

--- a/migrate-up.js
+++ b/migrate-up.js
@@ -6,8 +6,10 @@ const path = require('path')
 const connectionString = `postgres://${process.env.DATABASE_USERNAME}:${process.env.DATABASE_PASSWORD}@${process.env.DATABASE_HOST}/${process.env.DATABASE_DATABASE}`
 const cmd = `node_modules/.bin/sequelize db:migrate --url="${connectionString}" --migrations-path="${path.join(__dirname, 'migrations')}"`
 
-exec(cmd, (error, stdout, stderr) => {
-  if (error) {
-    throw new Error(error)
-  }
-})
+setTimeout(() => {
+  exec(cmd, (error, stdout, stderr) => {
+    if (error) {
+      throw new Error(error)
+    }
+  })
+}, 7500)

--- a/migrate-up.js
+++ b/migrate-up.js
@@ -4,7 +4,7 @@ const exec = require('child_process').exec
 const path = require('path')
 
 const connectionString = `postgres://${process.env.DATABASE_USERNAME}:${process.env.DATABASE_PASSWORD}@${process.env.DATABASE_HOST}/${process.env.DATABASE_DATABASE}`
-const cmd = `node_modules/sequelize-cli/bin/sequelize db:migrate --url="${connectionString}" --migrations-path="${path.join(__dirname, 'migrations')}"`
+const cmd = `node_modules/.bin/sequelize db:migrate --url="${connectionString}" --migrations-path="${path.join(__dirname, 'migrations')}"`
 
 exec(cmd, (error, stdout, stderr) => {
   if (error) {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   "license": "ISC",
   "dependencies": {
     "aws-sdk": "^2.67.0",
-    "bluebird": "^3.5.0",
+    "bluebird": "^3.5.5",
     "boom": "^4.3.1",
-    "bunyan": "^1.8.10",
+    "bunyan": "^1.8.12",
     "hapi": "^16.1.1",
     "hapi-bunyan": "^0.7.0",
     "hapi-swagger": "^7.7.0",
@@ -22,12 +22,12 @@
     "joi": "^10.4.1",
     "pg": "^6.1.5",
     "require-directory": "^2.1.1",
-    "sequelize": "^3.30.4",
-    "uuid": "^3.0.1",
+    "sequelize": "^5.9.2",
+    "uuid": "^3.3.2",
     "vision": "^4.1.1"
   },
   "devDependencies": {
-    "sequelize-cli": "^2.7.0",
+    "sequelize-cli": "^5.5.0",
     "supervisor": "^0.12.0"
   }
 }


### PR DESCRIPTION
Wanted to fix the sequelize security warnings that Github has been showing/emailing. This PR just updates sequelize plus some of the smaller/minor version updates to packages

There is a whole long list of warnings since the hapi packages have moved under a new repository, but I dont want to touch those for now. Maybe @pon-noyo some day you can bump 